### PR TITLE
Update package.json to publish json and spritesheets

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,24 @@
     "LICENSE",
     "README.md",
     "emoji.json",
-    "emoji_pretty.json"
+    "emoji_pretty.json",
+    "sheet_apple_16.png",
+    "sheet_apple_20.png",
+    "sheet_apple_32.png",
+    "sheet_apple_64.png",
+    "sheet_emojione_16.png",
+    "sheet_emojione_20.png",
+    "sheet_emojione_32.png",
+    "sheet_emojione_64.png",
+    "sheet_google_16.png",
+    "sheet_google_20.png",
+    "sheet_google_32.png",
+    "sheet_google_64.png",
+    "sheet_twitter_16.png",
+    "sheet_twitter_20.png",
+    "sheet_twitter_32.png",
+    "sheet_twitter_64.png"
   ],
-  "dependencies": {
-    "images": "https://github.com/iamcal/emoji-data/archive/v2.4.2.tar.gz"
-  },
   "bugs": {
     "url": "https://github.com/iamcal/emoji-data/issues"
   },


### PR DESCRIPTION
Adds spritesheets to the NPM package to solve #41  

The total package with the json-data and spritesheets weights 39.4mb, which in my test publish was accepted by NPM (can't find any documentation about a hard limit). 

There's still an issue with the package name being used by https://github.com/mroth/emoji-data-js, but I'll leave it up to you to come up with an alternate name, or maybe ask @mroth if they can rename their package on NPM (it hasn't been updated for over 2 years).

I also removed the previous "images" dependency which pointed to a tarball containing this package, and thus creating a circular dependency. I'm not sure what purpose it served.

A big bonus if we get this published is that the spritesheet assets will then be available via CDN (https://npmcdn.com/).

Long term I think you could get sponsoring from a CDN provider, to publish the individual assets as part of the release process (unless copyright becomes an issue). But I think this is the best intermediate solution for us wanting to consume the emoji data :)