### PR TITLE
Ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/apple/apple_color_emoji_*.ttf
 build/windows10/seguiemj.ttf
+node_modules


### PR DESCRIPTION
Was working on a PR and realized that `node_modules` weren't being ignored. I can see someone making the case that it belongs in a global gitignore, but in my experience I often see them ignored on a per-project basis, too.