### PR TITLE
Make :* result in kissing_heart instead of kiss

### DIFF
--- a/build/data_text_toemoji.txt
+++ b/build/data_text_toemoji.txt
@@ -15,8 +15,8 @@ c:	smile
 :'(	cry
 =)	smiley
 =-)	smiley
-:*	kiss
-:-*	kiss
+:*	kissing_heart
+:-*	kissing_heart
 :>	laughing
 :->	laughing
 8)	sunglasses


### PR DESCRIPTION
Currently, `:*` shows up as 💋 . However, experts believe it should show up as 😘 . This fixes that discrepancy.