### PR TITLE
Add Facebook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ available versions. If you're looking for older versions of Apple of Android ima
 
 * Apple Emoji: Copyright &copy; Apple Inc. - OS X 10.11.1
 * Android Emoji: Copyright &copy; [The Android Open Source Project](https://s3-eu-west-1.amazonaws.com/tw-font/android/NOTICE) - Lollipop
-* Twitter Emoji Copyright &copy; Twitter, Inc. - The original release
+* Twitter Emoji: Copyright &copy; Twitter, Inc. - The original release
 * Emoji One Emoji: Copyright &copy; [Ranks.com Inc.](http://www.emojione.com/developers) - master as of 2015-03-05
+* Facebook Emoji: Copyright &copy; Facebook, Inc. - v7
 
 ## Libraries which use this data
 
@@ -54,6 +55,7 @@ look like this:
 			"has_img_google": true,
 			"has_img_twitter": true,
 			"has_img_emojione": false,
+			"has_img_facebook": false,
 			"skin_variations": {
 				"261D-1F3FB": {
 					"unified": "261D-1F3FB",
@@ -64,6 +66,7 @@ look like this:
 					"has_img_google": false,
 					"has_img_twitter": false,
 					"has_img_emojione": false
+					"has_img_facebook": false
 				},
 				...
 			}

--- a/build/build_sheets.php
+++ b/build/build_sheets.php
@@ -1,21 +1,14 @@
 <?php
 	$dir = dirname(__FILE__).'/..';
 
-	build_sheet('apple', 32);
-	build_sheet('apple', 20);
-	build_sheet('apple', 16);
+	$sets = array('apple', 'twitter', 'google', 'emojione', 'facebook');
+	$sizes = array(16, 20, 32);
 
-	build_sheet('twitter', 32);
-	build_sheet('twitter', 20);
-	build_sheet('twitter', 16);
-
-	build_sheet('google', 32);
-	build_sheet('google', 20);
-	build_sheet('google', 16);
-
-	build_sheet('emojione', 32);
-	build_sheet('emojione', 20);
-	build_sheet('emojione', 16);
+	foreach ($sets as $set) {
+		foreach ($sizes as $size) {
+			build_sheet($set, $size);
+		}
+	}
 
 	function build_sheet($type, $size){
 

--- a/build/build_table.php
+++ b/build/build_table.php
@@ -2,7 +2,6 @@
 	$in = file_get_contents('../emoji.json');
 	$catalog = json_decode($in, true);
 
-
 	function format_codepoints($raw){
 
 		if (!$raw) return '-';
@@ -54,19 +53,18 @@
 ?>
 <html>
 <head>
-<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta charset="UTF-8" />
 <title>Emoji Catalog</title>
 <link rel="stylesheet" type="text/css" media="all" href="emoji.css" />
 <style type="text/css">
 
 body {
     font-size: 12px;
-    font-family: Arial, Helvetica, sans-serif;
+    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
 }
 
 table {
-    -webkit-border-radius: 0.41em;
-    -moz-border-radius: 0.41em;
+    border-radius: 0.41em;
     border: 1px solid #999;
     font-size: 12px;
 }
@@ -101,7 +99,7 @@ table tbody td {
 
 <table cellspacing="0" cellpadding="0">
 	<tr>
-		<th colspan="6">Name</th>
+		<th colspan="7">Name</th>
 		<th>Short Name</th>
 		<th>ASCII</th>
 		<th>Unified</th>
@@ -121,12 +119,14 @@ table tbody td {
 		$url_google   = $row['has_img_google'  ] ? "img-google-64/{$row['image']}"   : '';
 		$url_twitter  = $row['has_img_twitter' ] ? "img-twitter-64/{$row['image']}"  : '';
 		$url_emojione = $row['has_img_emojione'] ? "img-emojione-64/{$row['image']}" : '';
+		$url_facebook = $row['has_img_facebook'] ? "img-facebook-64/{$row['image']}" : '';
 
 		echo "\t<tr>\n";
 		echo "\t\t<td><img src=\"{$url_apple}\" width=\"20\" height=\"20\" /></td>\n";
 		echo "\t\t<td><img src=\"{$url_google}\" width=\"20\" height=\"20\" /></td>\n";
 		echo "\t\t<td><img src=\"{$url_twitter}\" width=\"20\" height=\"20\" /></td>\n";
 		echo "\t\t<td><img src=\"{$url_emojione}\" width=\"20\" height=\"20\" /></td>\n";
+		echo "\t\t<td><img src=\"{$url_facebook}\" width=\"20\" height=\"20\" /></td>\n";
 		echo "\t\t<td>".unicode_bytes($row['unified'])."</td>\n";
 		echo "\t\t<td>".HtmlSpecialChars(StrToLower($row['name']))."</td>\n";
 

--- a/build/facebook/README.md
+++ b/build/facebook/README.md
@@ -13,6 +13,6 @@ Next you'll want to cut the 64px versions that are used in the sheets:
 And finally optimize them. This requires the optimizing tools in `build/README.md` to be installed
 and takes a very long time:
 
-    ../optimize.sh ../../img-twitter-64/*
+    ../optimize.sh ../../img-facebook-64/*
 
 The resulting 64px images are then ready to use.

--- a/build/facebook/README.md
+++ b/build/facebook/README.md
@@ -1,0 +1,18 @@
+# Building the Facebook emoji images
+
+From any machine:
+
+    php grab.php
+
+This will fetch the 128px versions of all available emoji.
+
+Next you'll want to cut the 64px versions that are used in the sheets:
+
+    php make64.php
+
+And finally optimize them. This requires the optimizing tools in `build/README.md` to be installed
+and takes a very long time:
+
+    ../optimize.sh ../../img-twitter-64/*
+
+The resulting 64px images are then ready to use.

--- a/build/facebook/grab.php
+++ b/build/facebook/grab.php
@@ -1,0 +1,63 @@
+<?php
+$json = file_get_contents('../../emoji.json');
+$data = json_decode($json, true);
+shell_exec("rm -f ../../img-facebook-128/*.png");
+foreach ($data as $row){
+	if (strlen($row['image'])) fetch($row['image']);
+	if (isset($row['skin_variations'])){
+		foreach ($row['skin_variations'] as $row2){
+			fetch($row2['image']);
+		}
+	}
+}
+function fetch($img){
+	/* based upon Twitter scraper and Javascript from Facebook see Github issue #56 */
+	
+	/* Emoji Config */
+	$pixelRatio = 1;
+	$schemaAuth = "https://www.facebook.com/images/emoji.php/v7";
+	$fileExt = ".png";
+	$supportedSizes = [16, 18, 20, 24, 28, 30, 32, 64, 128];
+	$types = array('FBEMOJI' => 'f', 'FB_EMOJI_EXTENDED' => 'e', 'MESSENGER' => 'z', 'UNICODE' => 'u');
+	/** hardcoded defaults: */
+	$size = 128; // default = highest available
+	$type = $types['FBEMOJI'];
+	
+	$size = in_array($size, $supportedSizes) ? $size : 128;
+	$path = $pixelRatio . '/' . $size . '/' . $img . $fileExt;
+	$check = checksum($path);
+	$url_img = $schemaAuth . '/' . $type . $check . '/' . $path;
+	
+	$path = "../../img-facebook-128/{$img}"; /** files get stored here */
+	$url = $schemaAuth . $url_img; /** files get retrieved from here */
+	#echo "{$img} - $path - $url\n";
+	#continue;
+	$out = array();
+	$ret = 0;
+	exec("wget -qO {$path} \"{$url}\"", $out, $ret);
+	if ($ret){
+		echo "X[{$img}]";
+		#print_r($out);
+		if (file_exists($path) && !filesize($path)) unlink($path);
+	}else{
+		echo ".";
+	}
+}
+function encodeURIComponent($str) { /* a standard method in Javascript */
+	return $str;
+}
+function unescape($str) {
+	$trans = array('&amp;' => '&', '&lt;' => '<', '&gt;' => '>', '&quot;' => '"', '&#x27;' => "'");
+	return strtr($str, $trans);
+}
+function checksum($subpath) {
+	$checksumBase = 317426846;
+	$base = $checksumBase;
+//	$subpath = unescape(encodeURIComponent($subpath)); 
+	for ($pos = 0; $pos < strlen($subpath); $pos++) {
+		$base = ($base << 5) - $base + ord(substr($subpath, $pos, 1));
+		$base &= 4294967295;
+	}
+	return base_convert(($base & 255), 10, 16);
+}
+?>

--- a/build/facebook/make64.php
+++ b/build/facebook/make64.php
@@ -1,0 +1,16 @@
+<?php
+	$files = glob("../../img-facebook-128/*.png");
+	shell_exec("rm -f ../../img-facebook-64/*.png");
+	foreach ($files as $src){
+		$bits = explode('/', $src);
+		$dst = '../../img-facebook-64/'.array_pop($bits);
+		exec("convert {$src} -resize 64x64 png32:{$dst}", $out, $code);
+		if ($code){
+			echo "ERROR:\n";
+			echo "   ".$out."\n";
+		}else{
+			echo ".";
+		}
+	}
+	echo "All done\n";
+?>

--- a/build/find_flags.php
+++ b/build/find_flags.php
@@ -7,8 +7,9 @@
 	$b = find_flags("../img-google-64/1f1*-1f1*.png");
 	$c = find_flags("../img-twitter-64/1f1*-1f1*.png");
 	$d = find_flags("../img-emojione-64/1f1*-1f1*.png");
+	$e = find_flags("../img-facebook-64/1f1*-1f1*.png"); # 1f1*_1f1*.png?
 
-	$all = array_unique(array_merge($a, $b, $c, $d));
+	$all = array_unique(array_merge($a, $b, $c, $d, $e));
 	sort($all);
 
 	foreach ($all as $line) echo $line;

--- a/build/find_unused.php
+++ b/build/find_unused.php
@@ -41,6 +41,7 @@
 	scan_unused($files, '../img-google-64/');
 	scan_unused($files, '../img-twitter-64/');
 	scan_unused($files, '../img-emojione-64/');
+	scan_unused($files, '../img-facebook-64/');
 	echo "~FIN~\n";
 
 	function scan_unused($files, $path){

--- a/build/quant_sheets.sh
+++ b/build/quant_sheets.sh
@@ -32,7 +32,7 @@ quant_sheet() {
 	fi
 }
 
-for type in apple google twitter emojione; do
+for type in apple google twitter emojione facebook; do
 	for size in 16 20 32 64; do
 		for colors in 128 256; do
 			echo "Quantizing ${type}_${size} to ${colors} colors"


### PR DESCRIPTION
This patch is intended to fix #56, but is completely untested. It’s just a layman’s transform from [JS](https://gist.github.com/Crissov/5bbf9704995317c20955ab2d0caf1045) to PHP.

It currently only deals with standard Facebook emoji graphics, but Messenger should be simple to add, since it only requires changing a single parameter (`$type = $types['MESSENGER']`, which will turn `f` into `z`). I haven’t tested whether older images are still available from Facebook if one merely changes `/v7` to something smaller. I don’t know whether the check-sum base is static and constant, but it works for me right now.

I kept descriptive variable and function names from Facebook’s source code where they were used and changed single-letter variables to more speaking ones.