### PR TITLE
Minor update to build_map.php

### DIFF
--- a/build/build_map.php
+++ b/build/build_map.php
@@ -329,7 +329,7 @@
 
 	function build_character_data($img_key, $short_names){
 
-		global $text;
+		global $text, $texts;
 
 		$uni = StrToUpper($img_key);
 


### PR DESCRIPTION
make $texts also global in build_character_data(), like $text – not sure whether either is required as they are only used in simple_row() with $GLOBALS[]