### PR TITLE
Fix invalid utf8 json encode failure

### DIFF
--- a/build/build_map.php
+++ b/build/build_map.php
@@ -958,9 +958,15 @@
 
 	echo "Saving categories : ";
 
-	$fh = fopen('../categories.json', 'w');
-	fwrite($fh, json_encode($categories, JSON_PRETTY_PRINT));
-	fclose($fh);
+	$json_cat = json_encode($categories, JSON_PRETTY_PRINT);
+	if ($json_cat) {
+		$fh = fopen('../categories.json', 'w');
+		fwrite($fh, $json_cat);
+		fclose($fh);
+	} else {
+		$json_err = json_last_error();
+		echo "\nERROR: json encode error: {$json_err}\n";
+	}
 
 	echo "DONE\n";
 
@@ -1036,18 +1042,30 @@
 
 	echo "Writing map : ";
 
-	$fh = fopen('../emoji.json', 'w');
-	fwrite($fh, json_encode($out));
-	fclose($fh);
+	$json_emoji = json_encode($out);
+	if ($json_emoji) {
+		$fh = fopen('../emoji.json', 'w');
+		fwrite($fh, $json_emoji);
+		fclose($fh);
+	} else {
+		$json_err = json_last_error();
+		echo "\nERROR: json encode error: {$json_err}\n";
+	}
 
 	echo "DONE\n";
 
 
 	echo "Writing pretty map : ";
 
-	$fh = fopen('../emoji_pretty.json', 'w');
-	fwrite($fh, json_encode($out, JSON_PRETTY_PRINT));
-	fclose($fh);
+	$json_pretty = json_encode($out, JSON_PRETTY_PRINT);
+	if ($json_pretty) {
+		$fh = fopen('../emoji_pretty.json', 'w');
+		fwrite($fh, $json_pretty);
+		fclose($fh);
+	} else {
+		$json_err = json_last_error();
+		echo "\nERROR: json encode error: {$json_err}\n";
+	}
 
 	echo "DONE\n";
 

--- a/build/build_map.php
+++ b/build/build_map.php
@@ -306,7 +306,7 @@
 
 	foreach ($raw as $line){
 		list($line, $junk) = explode('#', $line);
-		list($key, $var) = explode(';', StrToUpper(trim($line)));
+		list($key, $var) = explode(';', mb_strtoupper(trim($line)));
 		if (strlen($key)){
 			$obsoleted_by[$key] = $var;
 			$obsoletes[$var] = $key;
@@ -365,7 +365,7 @@
 	foreach ($catalog as $row){
 
 		$img_key = StrToLower(encode_points($row['unicode']));
-		$shorts = $short_names[StrToUpper($img_key)];
+		$shorts = $short_names[mb_strtoupper($img_key)];
 		$name = $row['char_name']['title'];
 
 		if (preg_match("!^REGIONAL INDICATOR SYMBOL LETTERS !", $name)){
@@ -404,7 +404,7 @@
 
 			add_row($img_key, $names, array(
 				'unified'	=> $uid,
-				'name'		=> "REGIONAL INDICATOR SYMBOL LETTERS ".StrToUpper(substr($names[0], 5)),
+				'name'		=> "REGIONAL INDICATOR SYMBOL LETTERS ".mb_strtoupper(substr($names[0], 5)),
 			));
 		}else{
 			add_row($img_key, $names);
@@ -467,7 +467,7 @@
 
 		if (isset($GLOBALS['skip_components'][$hex_low])) continue;
 
-		$hex_up = StrToUpper($hex_low);
+		$hex_up = mb_strtoupper($hex_low);
 		$line = shell_exec("grep -e ^{$hex_up}\\; unicode/UnicodeData.txt");
 		$line = trim($line);
 
@@ -692,10 +692,10 @@
 		}
 
 		if (!isset($props['name'])){
-			$props['name'] = $GLOBALS['names_map'][StrToUpper($img_key)];
+			$props['name'] = $GLOBALS['names_map'][mb_strtoupper($img_key)];
 		}
 		if (!isset($props['unified'])){
-			$props['unified'] = StrToUpper($img_key);
+			$props['unified'] = mb_strtoupper($img_key);
 		}
 
 		$row = simple_row($img_key, $short_names, $props);
@@ -718,7 +718,7 @@
 
 		$nq = null;
 		if ($GLOBALS['rev_qualified_map'][$img_key]){
-			$nq = StrToUpper($GLOBALS['rev_qualified_map'][$img_key]);
+			$nq = mb_strtoupper($GLOBALS['rev_qualified_map'][$img_key]);
 			if (!$added){
 				$added = $GLOBALS['versions'][StrToLower($nq)];
 			}
@@ -764,7 +764,7 @@
 			}
 		}else{
 			if ($GLOBALS['sequence_names'][$img_key]){
-				$props['name'] = StrToUpper($GLOBALS['sequence_names'][$img_key]);
+				$props['name'] = mb_strtoupper($GLOBALS['sequence_names'][$img_key]);
 			}
 		}
 
@@ -815,13 +815,13 @@
 
 			foreach ($GLOBALS['skin_variation_suffixes'] as $suffix){
 
-				$var_uni	= StrToUpper($skin_vars_base.'-'.$suffix);
+				$var_uni	= mb_strtoupper($skin_vars_base.'-'.$suffix);
 				$var_img_key	= StrToLower($skin_vars_base.'-'.$suffix);
 				$var_img	= $var_img_key.'.png';
 
 				$var_nq = null;
 				if ($GLOBALS['rev_qualified_map'][$var_img_key]){
-					$var_nq = StrToUpper($GLOBALS['rev_qualified_map'][$var_img_key]);
+					$var_nq = mb_strtoupper($GLOBALS['rev_qualified_map'][$var_img_key]);
 				}
 
 


### PR DESCRIPTION
I noticed an issue while running the build script that the `rescue worker’s helmet` line parsed from emoji-sequences.txt was resulting in invalid utf8 and a failed json_encode (leading to empty emoji.json and pretty files)

This fixes that by using `mb_strtoupper` instead of `StrToUpper` in build_map.php. The specific line that fixed it was:

https://github.com/iamcal/emoji-data/blob/045732a02b2efbc3ee24ce36d598caba28f7f909/build/build_map.php#L767

Also added error logging for bad json_encodes and prevent blanking the json files if that happens.