### PR TITLE
add aliases for homosexual couples

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 2022-11-14 : v14.0.2
+
+* Codepoint `U+1F46C TWO MEN HOLDING HANDS` now has `:couple:` and `:man_and_man_holding_hands:` as an alias
+* Codepoint `U+1F46D TWO WOMEN HOLDING HANDS` now has `:couple:` and `:woman_and_woman_holding_hands:` as an alias
+
 
 ## ????-??-?? : v14.0.1
 

--- a/build/data_emoji_names.txt
+++ b/build/data_emoji_names.txt
@@ -347,8 +347,8 @@
 1F469;woman
 1F46A;family
 1F46B;man_and_woman_holding_hands/woman_and_man_holding_hands/couple
-1F46C;two_men_holding_hands/men_holding_hands
-1F46D;two_women_holding_hands/women_holding_hands
+1F46C;two_men_holding_hands/men_holding_hands/man_and_man_holding_hands/couple
+1F46D;two_women_holding_hands/women_holding_hands/woman_and_woman_holding_hands/couple
 1F46E;cop
 1F46F;dancers
 1F470;bride_with_veil

--- a/emoji_pretty.json
+++ b/emoji_pretty.json
@@ -27000,7 +27000,9 @@
         "short_name": "two_men_holding_hands",
         "short_names": [
             "two_men_holding_hands",
-            "men_holding_hands"
+            "men_holding_hands",
+            "man_and_man_holding_hands",
+            "couple"
         ],
         "text": null,
         "texts": null,
@@ -27329,7 +27331,9 @@
         "short_name": "two_women_holding_hands",
         "short_names": [
             "two_women_holding_hands",
-            "women_holding_hands"
+            "women_holding_hands",
+            "woman_and_woman_holding_hands",
+            "couple"
         ],
         "text": null,
         "texts": null,


### PR DESCRIPTION
Typing `:couple:` should also show emojis for 👭 and 👬. 

<img width="215" alt="image" src="https://user-images.githubusercontent.com/28842311/201654810-ab7f56ef-4b1f-4e26-8fbc-a2fef1305f4e.png">
