### PR TITLE
Replace Ruby emoji library in Readme with supported one

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ missing emoji (see the spritesheet section above for more details).
 * https://github.com/iamcal/js-emoji - JavaScript emoji library
 * https://github.com/iamcal/php-emoji - PHP emoji library
 * https://github.com/mroth/emoji-data-js - NodeJS emoji library
-* https://github.com/mroth/emoji_data.rb - Ruby emoji library
+* https://github.com/jpalumickas/emoji-datasource-ruby - Ruby emoji library
 * https://github.com/mroth/exmoji - Elixir/Erlang emoji library
 * https://github.com/needim/wdt-emoji-bundle - a Slack-style JavaScript emoji picker
 * https://github.com/mroth/emojistatic - emoji image CDN


### PR DESCRIPTION
Unfortunately currently linked [`emoji_data`](https://github.com/mroth/emoji_data.rb) Ruby gem seems to be abandoned with [last published release on RubyGems](https://rubygems.org/gems/emoji_data) dating to year 2014.

There is newer supported alternative, based on current version of data files from this repository: [emoji-datasource](https://github.com/jpalumickas/emoji-datasource-ruby) gem (with [last release on RubyGems was published 2 weeks ago](https://rubygems.org/gems/emoji-datasource))