### PR TITLE
Update README.md to reflect that emoji-mart is now a WebComponent since v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,4 +181,4 @@ missing emoji (see the spritesheet section above for more details).
 * https://github.com/maxoumime/emoji-data-java - Java/Kotlin emoji library
 * https://github.com/kyokomi/emoji - Golang emoji library
 * https://github.com/joeattardi/emoji-button - Plain JavaScript emoji picker
-* https://github.com/missive/emoji-mart - React emoji picker components
+* https://github.com/missive/emoji-mart - emoji picker WebComponent


### PR DESCRIPTION
Since v3 React is optional and it is "just" a web component.